### PR TITLE
Fix gcc 4.6 compile-time error

### DIFF
--- a/src/ndk_string.c
+++ b/src/ndk_string.c
@@ -94,7 +94,7 @@ u_char *
 ndk_vcatstrf (ngx_pool_t *pool, ngx_str_t *dest, const char *fmt, va_list args)
 {
     size_t          len, l, el;
-    int             argc, escape;
+    int             argc;
     u_char         *p, *m, *e, c, c1, *cp;
 
     argc = strlen (fmt);
@@ -107,7 +107,6 @@ ndk_vcatstrf (ngx_pool_t *pool, ngx_str_t *dest, const char *fmt, va_list args)
     cp = cs;
 
     len = 0;
-    escape = 0;
 
     // TODO : maybe have 'e' at the beginning?
 
@@ -265,7 +264,6 @@ ndk_vcatstrf (ngx_pool_t *pool, ngx_str_t *dest, const char *fmt, va_list args)
 
         sp++;
         fmt++;
-        escape = 0;
     }
 
 


### PR DESCRIPTION
Was trying to build on debian wheezy and got a compile time error that escape is assigned but never used.
