### PR TITLE
src/ndk.h: do not #error if 'NDK' is undefined

### DIFF
--- a/src/ndk.h
+++ b/src/ndk.h
@@ -28,11 +28,6 @@
 #endif
 
 
-#if !(NDK)
-#error At least one module requires the Nginx Development Kit to be compiled with \
-the source (add --with-module=/path/to/devel/kit/src to configure command)
-#endif
-
 #include    <ndk_config.h>
 
 


### PR DESCRIPTION
The 'NDK' is only ever used to abort the compilation if it is not defined, having no other uses.

Passing `-DNDK` around each time a consumer of NDK is compiled needlessly complicates building other modules.

Fixes: #38 