### PR TITLE
Fix complex value scripts after nginx script engine change

### DIFF
--- a/config
+++ b/config
@@ -58,6 +58,11 @@ fi
 
 have=NDK . auto/have
 
+# Script engine capabilities cannot be inferred from versions across forks.
+if grep -q ngx_http_script_complex_value_end_code src/http/ngx_http_script.h 2>/dev/null; then
+    have=NDK_HAVE_HTTP_SCRIPT_COMPLEX_VALUE_END_CODE . auto/have
+fi
+
 ##############
 ## INCLUDES ##
 ##############

--- a/src/ndk_rewrite.c
+++ b/src/ndk_rewrite.c
@@ -5,6 +5,13 @@
  * be provided later to un-define them as being static
  */
 
+/* Added in nginx 1.31.3 and backported to 1.30.4; not in freenginx. */
+#if !defined(freenginx)                                               \
+    && (nginx_version >= 1030004)                                     \
+    && (nginx_version < 1031000 || nginx_version >= 1031003)
+#define NDK_HAVE_HTTP_SCRIPT_COMPLEX_VALUE_END_CODE
+#endif
+
 
 uintptr_t ndk_http_script_exit_code = (uintptr_t) NULL;
 
@@ -17,6 +24,9 @@ ndk_http_rewrite_value (ngx_conf_t *cf, ndk_http_rewrite_loc_conf_t *lcf,
     ngx_http_script_compile_t              sc;
     ngx_http_script_value_code_t          *val;
     ngx_http_script_complex_value_code_t  *complex;
+#ifdef NDK_HAVE_HTTP_SCRIPT_COMPLEX_VALUE_END_CODE
+    ngx_http_script_complex_value_end_code_t  *complex_end;
+#endif
 
     n = ngx_http_script_variables_count(value);
 
@@ -63,6 +73,17 @@ ndk_http_rewrite_value (ngx_conf_t *cf, ndk_http_rewrite_loc_conf_t *lcf,
         return NGX_CONF_ERROR;
     }
 
+#ifdef NDK_HAVE_HTTP_SCRIPT_COMPLEX_VALUE_END_CODE
+    complex_end = ngx_http_script_add_code(lcf->codes,
+                              sizeof(ngx_http_script_complex_value_end_code_t),
+                              &complex);
+    if (complex_end == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    complex_end->code = ngx_http_script_complex_value_end_code;
+#endif
+
     return NGX_CONF_OK;
 }
 
@@ -99,5 +120,3 @@ ndk_http_rewrite_var (ngx_http_request_t *r, ngx_http_variable_value_t *v,
 
     return  NGX_OK;
 }
-
-

--- a/src/ndk_rewrite.c
+++ b/src/ndk_rewrite.c
@@ -5,14 +5,6 @@
  * be provided later to un-define them as being static
  */
 
-/* Added in nginx 1.31.3 and backported to 1.30.4; not in freenginx. */
-#if !defined(freenginx)                                               \
-    && (nginx_version >= 1030004)                                     \
-    && (nginx_version < 1031000 || nginx_version >= 1031003)
-#define NDK_HAVE_HTTP_SCRIPT_COMPLEX_VALUE_END_CODE
-#endif
-
-
 uintptr_t ndk_http_script_exit_code = (uintptr_t) NULL;
 
 

--- a/src/ndk_rewrite.c
+++ b/src/ndk_rewrite.c
@@ -5,6 +5,7 @@
  * be provided later to un-define them as being static
  */
 
+
 uintptr_t ndk_http_script_exit_code = (uintptr_t) NULL;
 
 
@@ -112,3 +113,5 @@ ndk_http_rewrite_var (ngx_http_request_t *r, ngx_http_variable_value_t *v,
 
     return  NGX_OK;
 }
+
+

--- a/src/ndk_rewrite.h
+++ b/src/ndk_rewrite.h
@@ -3,14 +3,6 @@
 /* TODO : should remove this when not needed */
 
 
-/* Added in nginx 1.31.3 and backported to 1.30.4; not in freenginx. */
-#if !defined(freenginx)                                               \
-    && (nginx_version >= 1030004)                                     \
-    && (nginx_version < 1031000 || nginx_version >= 1031003)
-#define NDK_HAVE_HTTP_SCRIPT_COMPLEX_VALUE_END_CODE
-#endif
-
-
 
 /* used for plugging into the rewrite module (taken from the rewrite module) */
 

--- a/src/ndk_rewrite.h
+++ b/src/ndk_rewrite.h
@@ -3,6 +3,14 @@
 /* TODO : should remove this when not needed */
 
 
+/* Added in nginx 1.31.3 and backported to 1.30.4; not in freenginx. */
+#if !defined(freenginx)                                               \
+    && (nginx_version >= 1030004)                                     \
+    && (nginx_version < 1031000 || nginx_version >= 1031003)
+#define NDK_HAVE_HTTP_SCRIPT_COMPLEX_VALUE_END_CODE
+#endif
+
+
 
 /* used for plugging into the rewrite module (taken from the rewrite module) */
 


### PR DESCRIPTION
## Summary

Append `ngx_http_script_complex_value_end_code` after NDK-compiled complex
rewrite values when the nginx script engine provides that opcode.

Availability is detected at configure time from the actual nginx source tree,
not inferred from `nginx_version` or a fork name. The result is emitted as
`NDK_HAVE_HTTP_SCRIPT_COMPLEX_VALUE_END_CODE` through nginx's standard
`auto/have` mechanism. When the opcode is absent, the existing NDK code path is
unchanged.

## Problem

nginx commit
[`97e40e59`](https://github.com/nginx/nginx/commit/97e40e59b7b4ad6aa36f54ce4f1e64d1e98f24cb)
moved complex-value script finalization from
`ngx_http_script_complex_value_code` into a separate
`ngx_http_script_complex_value_end_code` opcode.

NDK contains a copy of the older `ngx_http_rewrite_value` implementation. It
compiles the value script but does not append the new terminating opcode. On
engines where pushing the value was deferred to that opcode, an NDK filter can
pop an uninitialized `ngx_http_variable_value_t`; with set-misc this is
observable as a SIGSEGV on the first request. On the later compatibility
implementation, omitting the opcode can instead leave an incorrect result
length and expose trailing bytes.

The C change mirrors the corresponding nginx rewrite compiler logic.

## Capability detection

Version-based detection is not reliable across source-compatible forks. For
example, Angie 1.12.0 and 1.12.1 both report
`nginx_version == 1031002`, but only Angie 1.12.1 provides
`ngx_http_script_complex_value_end_code`. The previous version guard therefore
left Angie 1.12.1 crashing.

The module `config` now checks the header used by the current build:

```sh
if grep -q ngx_http_script_complex_value_end_code src/http/ngx_http_script.h 2>/dev/null; then
    have=NDK_HAVE_HTTP_SCRIPT_COMPLEX_VALUE_END_CODE . auto/have
fi
```

nginx addon configuration runs from the nginx source root, so this uses the
same source tree against which the module is being built. This selects the
correct behavior for nginx, OpenResty, Angie, Tengine and FreeNginx without a
vendor/version matrix.

## Standalone reproducer

Example configuration using set-misc-nginx-module:

```nginx
error_log stderr notice;
pid /tmp/nginx-ndk-test.pid;

events {}

http {
    server {
        listen 127.0.0.1:18080;

        location / {
            set_unescape_uri $decoded $arg_u;
            return 200 "$decoded\n";
        }
    }
}
```

Control request:

```sh
curl -fsS \
    "http://127.0.0.1:18080/?u=http%3A%2F%2Fexample.com%2Fa%2520b.png"
```

Expected body:

```text
http://example.com/a%20b.png
```

## Validation

The baseline, previous PR revision and capability-detected revision were built
and exercised at the relevant script-engine boundaries:

| Server | Opcode | Result with capability detection |
| --- | --- | --- |
| nginx 1.30.3 | absent | Build/runtime unchanged; capability off |
| nginx 1.30.4 | present, deferred push | Correct response; no crash |
| nginx 1.31.2 | absent | Build/runtime unchanged; capability off |
| nginx 1.31.3 | present, deferred push | Correct response; no crash |
| nginx 1.31.4 and 1.31.5 | present, compatibility push | Correct response and exact length |
| OpenResty 1.29.2.5 and 1.31.1.1 | absent | Build/runtime unchanged; capability off |
| Angie 1.12.0 | absent | Build/runtime unchanged; capability off |
| Angie 1.12.1 | present, deferred push | Correct response; previous version guard crashes |
| Tengine 3.1.0 | absent | Build/runtime unchanged; capability off |
| Tengine 3.2.0-rc1 | present, deferred push | Correct response; no crash |
| Tengine 3.2.0-rc4 | present, compatibility push | Correct response and exact length |
| FreeNginx 1.31.2–1.31.4 | absent | Capability off |

The capability revision was also checked against the current nginx, FreeNginx,
Angie and Tengine heads available during testing.

Coverage included:

- static builds with debug symbols and the normal warnings-as-errors policy;
- dynamic `.so` builds with `--with-compat` and real `load_module` usage;
- `nginx -t` / `angie -t` and real set-misc requests;
- constant, single-value and multi-value paths;
- an exact-byte capture test (`31 3a 31`, with no trailing bytes);
- representative ASan builds at the crash boundaries;
- 1,000-request stress runs with concurrency 20.

The capability-detected variant passed every applicable check. On source trees
without the opcode, the generated macro remains absent and the patch introduces
no runtime code.

## Scope

This PR addresses only the complex-value end opcode. FreeNginx does not carry
that opcode, so this change correctly remains disabled there. The independent
FreeNginx source-compatibility work tracked in
[#41](https://github.com/vision5/ngx_devel_kit/pull/41) and subsequent
FreeNginx script-engine changes are outside this PR.
